### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,23 +6,23 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Arduino_NET KEYWORD1
-Arduino KEYWORD1
+Arduino_NET	KEYWORD1
+Arduino	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
-available KEYWORD2
-sendCommand KEYWORD2
-attach KEYWORD2
-process KEYWORD2
+begin	KEYWORD2
+available	KEYWORD2
+sendCommand	KEYWORD2
+attach	KEYWORD2
+process	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-END_MESSAGE LITERAL1
-ESCAPE_CHARACTER LITERAL1
-ARG_SEPARATOR LITERAL1
+END_MESSAGE	LITERAL1
+ESCAPE_CHARACTER	LITERAL1
+ARG_SEPARATOR	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords